### PR TITLE
Updated dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "dc": "^2.1.6",
-    "jquery": "^2.2.4"
+    "jquery": "^3.4.0"
   }
 }


### PR DESCRIPTION
npm throws audit alerts for jquery <= 3.4.0